### PR TITLE
Update infrastructure 20200126

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@
 
 # Tests
 tests/cov
+coverage.xml
+
+# IDEs
+/.idea
+
+# development stuff
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,12 @@
+<?php
+
+$config = PhpCsFixer\Config::create();
+$config->getFinder()
+    ->exclude('vendor')
+    ->in(__DIR__);
+$config->setRules([
+    '@PSR1' => true,
+    '@Symfony' => true
+]);
+
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     },
     "require-dev": {
         "phpunit/phpunit" : "^7",
-        "friendsofphp/php-cs-fixer": "^2"
+        "friendsofphp/php-cs-fixer": "2.16.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "sabre/tzserver",
     "description": "Timezone server",
     "require": {
-        "sabre/vobject": "~3.2"
+        "php": "^7.1",
+        "sabre/vobject": "^4.2"
     },
     "license": "BSD-3-Clause",
     "authors": [
@@ -15,5 +16,9 @@
         "psr-4" : {
             "Sabre\\TzServer\\" : "lib/"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit" : "^7",
+        "friendsofphp/php-cs-fixer": "^2"
     }
 }

--- a/lib/TzDataParser/Parser.php
+++ b/lib/TzDataParser/Parser.php
@@ -54,7 +54,7 @@ class Parser {
 
         if (count($line) < 9) {
             echo "Invalid rule: " . implode("--t--", $line);
-            break; 
+            return;
         }
         if (!isset($this->rules[$line[1]])) {
             $this->rules[$line[1]] = [];

--- a/lib/TzDataParser/Parser.php
+++ b/lib/TzDataParser/Parser.php
@@ -81,7 +81,6 @@ class Parser
                 print_r($line);
                 print_r($zone);
                 die();
-                break;
             }
             $until = null;
             if (isset($line[5])) {

--- a/lib/TzDataParser/Parser.php
+++ b/lib/TzDataParser/Parser.php
@@ -4,77 +4,71 @@ namespace Sabre\TzServer\TzDataParser;
 
 use Exception;
 
-class Parser {
-
-    public $rules = array();
-    public $zones = array();
+class Parser
+{
+    public $rules = [];
+    public $zones = [];
     protected $stream;
 
-    function parseFile($file) {
-
+    public function parseFile($file)
+    {
         $handle = fopen($file, 'r');
         if (!$handle) {
             throw new Exception("Could not open file: $file");
         }
         $this->stream = $handle;
         $this->parseStream();
-
     }
 
-    function parseStream() {
-
-        while($line = $this->getLine()) {
-
+    public function parseStream()
+    {
+        while ($line = $this->getLine()) {
             $this->parseLine($line);
-
         }
-
     }
 
-    protected function parseLine(array $line) { 
-
-        switch($line[0]) {
-            case 'Rule' :
+    protected function parseLine(array $line)
+    {
+        switch ($line[0]) {
+            case 'Rule':
                 $this->parseRule($line);
                 break;
-            case 'Zone' :
+            case 'Zone':
                 $this->parseZone($line);
                 break;
-            case 'Link' :
+            case 'Link':
                 break;
-            default :
-                echo "Unknown line: " . implode("\t", $line), "\n";
+            default:
+                echo 'Unknown line: '.implode("\t", $line), "\n";
                 break;
-
         }
-
     }
 
-    protected function parseRule(array $line) {
-
+    protected function parseRule(array $line)
+    {
         if (count($line) < 9) {
-            echo "Invalid rule: " . implode("--t--", $line);
+            echo 'Invalid rule: '.implode('--t--', $line);
+
             return;
         }
         if (!isset($this->rules[$line[1]])) {
             $this->rules[$line[1]] = [];
-        } 
+        }
         $this->rules[$line[1]][] = new Rule([
-            'name'   => $line[1],
-            'from'   => $line[2],
-            'to'     => $line[3],
-            'type'   => $line[4],
-            'in'     => $line[5],
-            'on'     => $line[6],
-            'at'     => $line[7],
-            'save'   => $line[8],
+            'name' => $line[1],
+            'from' => $line[2],
+            'to' => $line[3],
+            'type' => $line[4],
+            'in' => $line[5],
+            'on' => $line[6],
+            'at' => $line[7],
+            'save' => $line[8],
             'letter' => $line[9],
         ]);
-
     }
 
-    protected function parseZone(array $line) {
-
+    protected function parseZone(array $line)
+    {
         $zone = [
             'name' => $line[1],
             'rules' => [],
@@ -83,15 +77,15 @@ class Parser {
         $lastLine = null;
         do {
             if (count($line) < 5) {
-                echo "Invalid zone: " . implode("|", $line), ". Last line: " . implode("|", $lastLine) . "\n";
+                echo 'Invalid zone: '.implode('|', $line), '. Last line: '.implode('|', $lastLine)."\n";
                 print_r($line);
                 print_r($zone);
                 die();
-                break; 
+                break;
             }
             $until = null;
             if (isset($line[5])) {
-                $until = implode(' ', array_slice($line,5));
+                $until = implode(' ', array_slice($line, 5));
             }
             $zone['rules'][] = new ZoneLine([
                 'gmtoff' => $line[2],
@@ -100,52 +94,52 @@ class Parser {
                 'until' => $until,
             ]);
             if ($until) {
-
-                // If there was an 'until' clause, it means we need to 
+                // If there was an 'until' clause, it means we need to
                 // parse the next line as well.
                 $lastLine = $line;
                 $line = $this->getLine();
-                if (is_null($line)) break;
+                if (is_null($line)) {
+                    break;
+                }
 
-                // Sometimes there's 2, sometimes theres 3 empty parts 
-                // before the continuation rules starts. So we're 
+                // Sometimes there's 2, sometimes theres 3 empty parts
+                // before the continuation rules starts. So we're
                 // removing all empty parts, and addin them again.
-                while($line[0]==="") {
+                while ('' === $line[0]) {
                     array_shift($line);
                 }
                 // Adding two empty parts again.
-                array_unshift($line, "", "");
-                
+                array_unshift($line, '', '');
             }
-        } while($until);
+        } while ($until);
         $this->zones[$zone['name']] = new Zone($zone);
-
     }
 
-    protected function getLine() {
-
+    protected function getLine()
+    {
         do {
             $line = fgets($this->stream);
-            if ($line===false) return;
-            if ($line[0]==='#' || trim($line)=="") {
+            if (false === $line) {
+                return;
+            }
+            if ('#' === $line[0] || '' == trim($line)) {
                 continue;
             }
             // If we got here.. it's a valid line
-          
+
             // Stripping comments
-            if (strpos($line,'#')!==false) {
-                $line = rtrim(substr($line, 0, strpos($line,'#')));
+            if (false !== strpos($line, '#')) {
+                $line = rtrim(substr($line, 0, strpos($line, '#')));
             }
             // Is thee anything left?
-            if (!trim($line,"\t ")) {
+            if (!trim($line, "\t ")) {
                 continue;
             }
             break;
-        } while(true);
+        } while (true);
 
         $line = preg_split("/[\s]+/", $line);
+
         return $line;
-
     }
-
 }

--- a/lib/TzDataParser/TZDataObj.php
+++ b/lib/TzDataParser/TZDataObj.php
@@ -5,18 +5,17 @@ namespace Sabre\TzServer\TzDataParser;
 use Exception;
 use InvalidArgumentException;
 
-abstract class TZDataObj{
-
-    public function __construct(array $ruleParts) {
-
-        foreach($ruleParts as $k=>$v) {
+abstract class TZDataObj
+{
+    public function __construct(array $ruleParts)
+    {
+        foreach ($ruleParts as $k => $v) {
             $this->$k = $v;
         }
-
     }
 
     /**
-     * Parses a date-time string in the format:
+     * Parses a date-time string in the format:.
      *
      * 2014 Jun 04 21:56:01
      *
@@ -24,15 +23,19 @@ abstract class TZDataObj{
      * month, 0 for hour and minute.
      *
      * @param string $timeString
-     * @param int $offset
+     * @param int    $offset
+     *
      * @return int
      */
-    protected function parseTime($timeString, $offSet) {
-
-        if (!$timeString) return null;
+    protected function parseTime($timeString, $offSet)
+    {
+        if (!$timeString) {
+            return null;
+        }
 
         if (!preg_match('# ^ ([0-9]{4}) (?:\W)? ([A-Za-z]{3})? (?:\W)* ([0-9]+)? (?:\W)* ([0-9]{1,2}:[0-9]{1,2})? (:[0-9]+)?$ #x', trim($timeString), $matches)) {
-            throw new Exception('Unknown timeString: "' . trim($timeString) . '"');
+            throw new Exception('Unknown timeString: "'.trim($timeString).'"');
+
             return null;
         }
 
@@ -42,7 +45,7 @@ abstract class TZDataObj{
         }
 
         $time = isset($matches[4]) && $matches[4] ? $matches[4] : '00:00';
-        $time.= isset($matches[5])?$matches[5]:':00';
+        $time .= isset($matches[5]) ? $matches[5] : ':00';
         $time = explode(':', $time);
 
         // Even though time() works with UTC, our timestamps are actually local
@@ -52,16 +55,15 @@ abstract class TZDataObj{
             $time[1],
             $time[2],
             $month,
-            isset($matches[3])?$matches[3]:1,
+            isset($matches[3]) ? $matches[3] : 1,
             $matches[1]
         );
 
         return $time - $offSet;
-
     }
 
     /**
-     * Parses an offset string in the format:
+     * Parses an offset string in the format:.
      *
      * -05:00:00
      * 03:00:00
@@ -73,61 +75,63 @@ abstract class TZDataObj{
      * @param string $offsetString
      * @param int
      */
-    protected function parseOffset($offsetString) {
-
-        if ($offsetString==='0') {
+    protected function parseOffset($offsetString)
+    {
+        if ('0' === $offsetString) {
             return 0;
         }
         if (!preg_match('#^ (-)? ([0-9]{1,2}) : ([0-9]{2}) (?: : ([0-9]{2}))? $ #x', $offsetString, $matches)) {
-            throw new Exception('Unknown offset string: ' .$offsetString);
+            throw new Exception('Unknown offset string: '.$offsetString);
         }
 
-        $time = isset($matches[4])?$matches[4]:0;
-        $time+=$matches[3]*60;
-        $time+=$matches[2]*3600;
+        $time = isset($matches[4]) ? $matches[4] : 0;
+        $time += $matches[3] * 60;
+        $time += $matches[2] * 3600;
 
-        if ($matches[1]==='-') {
-            $time = 0-$time;
+        if ('-' === $matches[1]) {
+            $time = 0 - $time;
         }
+
         return $time;
-
     }
 
     /**
-     * Formats an offset in seconds to the following format:
+     * Formats an offset in seconds to the following format:.
      *
      * +0100
      * -0500
      * +002705
      *
      * @param int $offsetTime
+     *
      * @return string
      */
-    protected function formatOffset($offsetTime) {
-
+    protected function formatOffset($offsetTime)
+    {
         if (!is_int($offsetTime)) {
             throw new InvalidArgumentException('offsetTime MUST be an integer');
         }
 
-        $str = $offsetTime<0?'-':'+';
+        $str = $offsetTime < 0 ? '-' : '+';
         $offsetTime = abs($offsetTime);
 
-        $hours = floor($offsetTime/3600);
+        $hours = floor($offsetTime / 3600);
         $minutes = floor(($offsetTime / 60) % 60);
         $seconds = $offsetTime % 60;
 
-        $str.=sprintf('%02d%02d', $hours, $minutes);
-        if ($seconds>0) $str.=sprintf('%02d', $seconds);
+        $str .= sprintf('%02d%02d', $hours, $minutes);
+        if ($seconds > 0) {
+            $str .= sprintf('%02d', $seconds);
+        }
 
         return $str;
-
     }
 
     /**
      * Returns the month number, based on a month string.
      */
-    protected function getMonth($str) {
-
+    protected function getMonth($str)
+    {
         $monthMap = [
             'Jan' => 1,
             'Feb' => 2,
@@ -145,7 +149,5 @@ abstract class TZDataObj{
             return $monthMap[$str];
         }
         throw new Exception("Unknown month: $str");
-
     }
-
 }

--- a/lib/TzDataParser/Zone.php
+++ b/lib/TzDataParser/Zone.php
@@ -2,9 +2,8 @@
 
 namespace Sabre\TzServer\TzDataParser;
 
-class Zone extends TZDataObj {
-
+class Zone extends TZDataObj
+{
     public $name;
-    public $rules = []; 
-
+    public $rules = [];
 }

--- a/lib/TzDataParser/ZoneLine.php
+++ b/lib/TzDataParser/ZoneLine.php
@@ -2,20 +2,19 @@
 
 namespace Sabre\TzServer\TzDataParser;
 
-class ZoneLine extends TZDataObj {
-
+class ZoneLine extends TZDataObj
+{
     public $gmtoff;
     public $rules;
     public $format;
-    public $until; 
+    public $until;
 
     /**
      * Returns the 'until' time as a unix timestamp.
      */
-    public function getUntil() {
-
+    public function getUntil()
+    {
         return $this->parseTime($this->until, $this->getOffset());
-
     }
 
     /**
@@ -23,10 +22,8 @@ class ZoneLine extends TZDataObj {
      *
      * @return int
      */
-    public function getOffset() {
-
+    public function getOffset()
+    {
         return $this->parseOffset($this->gmtoff);
-
     }
-
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+  level: 7
+  bootstrap: %currentWorkingDirectory%/vendor/autoload.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,2 @@
 parameters:
   level: 7
-  bootstrap: %currentWorkingDirectory%/vendor/autoload.php

--- a/tests/TZDataParser/RuleTest.php
+++ b/tests/TZDataParser/RuleTest.php
@@ -4,8 +4,9 @@ namespace Sabre\TzServer\TzDataParser;
 
 use DateTime;
 use DateTimeZone;
+use PHPUnit\Framework\TestCase;
 
-class RuleTest extends \PHPUnit_Framework_TestCase {
+class RuleTest extends TestCase {
 
     function getRule($yearUntil = 'only') {
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -4,11 +4,14 @@
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"
-  strict="true"
+  beStrictAboutTestsThatDoNotTestAnything="true"
+  beStrictAboutOutputDuringTests="true"
   >
-  <testsuite name="Sabre\TzServer">
-      <directory>TZDataParser</directory>
-  </testsuite>
+  <testsuites>
+    <testsuite name="Sabre\TzServer">
+        <directory>TZDataParser</directory>
+    </testsuite>
+  </testsuites>
 
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
1st commit:
- require PHP 7.1 or later, and phpunit v7
- add php-cs-fixer v2
- add `phpstan.neon` so we can run that if we want
- add "standard" stuff to `.gitignore`

2nd commit:
- apply php-cs-fixer changes with:
```
./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix lib --diff
```
A run of phpunit gives:
```
./vendor/phpunit/phpunit/phpunit --verbose --configuration tests/phpunit.xml
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.14-1+ubuntu18.04.1+deb.sury.org+1 with Xdebug 2.9.1
Configuration: /home/phil/git/sabre-io/sabre-tzserver/tests/phpunit.xml

...                                                                 3 / 3 (100%)

Time: 23 ms, Memory: 4.00 MB

OK (3 tests, 3 assertions)
```

It looks like this repo has not been touched for a while. It is easy to update it with this stuff.

Then someone can say if it is used.