### PR TITLE
Implement CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+
+matrix:
+  fast_finish: true
+
+install:
+  - composer require --dev phpstan/phpstan:^0.12
+
+before_script:
+  - composer install
+
+script:
+  - ./vendor/bin/php-cs-fixer fix lib/ --dry-run --diff
+  - ./vendor/bin/phpstan.phar analyse -c phpstan.neon lib
+  - ./vendor/bin/phpunit --configuration tests/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     },
     "require-dev": {
         "phpunit/phpunit" : "^7",
-        "friendsofphp/php-cs-fixer": "2.16.*"
+        "friendsofphp/php-cs-fixer": "~2.16.1"
     }
 }

--- a/lib/TzDataParser/TZDataObj.php
+++ b/lib/TzDataParser/TZDataObj.php
@@ -27,7 +27,7 @@ abstract class TZDataObj
      *
      * @return int
      */
-    protected function parseTime($timeString, $offSet)
+    protected function parseTime($timeString, $offset)
     {
         if (!$timeString) {
             return null;
@@ -59,7 +59,7 @@ abstract class TZDataObj
             $matches[1]
         );
 
-        return $time - $offSet;
+        return $time - $offset;
     }
 
     /**
@@ -73,7 +73,8 @@ abstract class TZDataObj
      * Returns the offset in seconds from GMT.
      *
      * @param string $offsetString
-     * @param int
+     *
+     * @return int
      */
     protected function parseOffset($offsetString)
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,2 +1,2 @@
 parameters:
-  level: 7
+  level: 0


### PR DESCRIPTION
- specify php-cs-fixer min version 2.16.1 to support PHP 7.4
- fix a couple of easy var naming and PHPdoc things pointed out by low-level phpstan
- add a simple `.travis.yml` to ru `php-cs-fixer` `phpstan` (level 0 only) and `phpunit`

Note `phpstan` at levels higher than 0 reports things that are probably bugs. I will lok at those in a later PR. I don't want to get "implement CI" mixed up with bug fixing.