### PR TITLE
Migrate configuration of tests/phpunit.xml

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,21 +1,13 @@
-<phpunit
-  colors="true"
-  bootstrap="bootstrap.php"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  beStrictAboutTestsThatDoNotTestAnything="true"
-  beStrictAboutOutputDuringTests="true"
-  >
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="bootstrap.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutOutputDuringTests="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">../lib/</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="Sabre\TzServer">
-        <directory>.</directory>
+      <directory>.</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist addUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">../lib/</directory>
-   </whitelist>
-  </filter>
 </phpunit>


### PR DESCRIPTION
https://travis-ci.com/github/sabre-io/sabre-tzserver/jobs/457153942
```
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

I did:
```
composer install
php vendor/bin/phpunit --migrate-configuration --configuration tests/phpunit.xml
```

Possibly this will break unit tests on older PHP  versions - let's see.